### PR TITLE
Support all hooks

### DIFF
--- a/packages/ogh-core/src/gitHooks.ts
+++ b/packages/ogh-core/src/gitHooks.ts
@@ -2,31 +2,52 @@ import { access, constants, readFile, readFileSync, writeFile } from "fs";
 import { resolve } from "path";
 import { getGitHooksDirectory } from "./git";
 
+// see https://git-scm.com/docs/githooks
 export type Hook =
-  | "applypatch-msg"
-  | "commit-msg"
-  | "fsmonitor-watchman"
-  | "post-update"
-  | "pre-applypatch"
-  | "pre-commit"
-  | "pre-push"
-  | "pre-rebase"
-  | "pre-receive"
-  | "prepare-commit-msg"
-  | "update";
+  | "applypatch-msg" // https://git-scm.com/docs/githooks#_applypatch_msg
+  | "pre-applypatch" // https://git-scm.com/docs/githooks#_pre_applypatch
+  | "post-applypatch" // https://git-scm.com/docs/githooks#_post_applypatch
+  | "pre-commit" // https://git-scm.com/docs/githooks#_pre_commit
+  | "prepare-commit-msg" // https://git-scm.com/docs/githooks#_prepare_commit_msg
+  | "commit-msg" // https://git-scm.com/docs/githooks#_commit_msg
+  | "post-commit" // https://git-scm.com/docs/githooks#_post_commit
+  | "pre-rebase" // https://git-scm.com/docs/githooks#_pre_rebase
+  | "post-checkout" // https://git-scm.com/docs/githooks#_post_checkout
+  | "post-merge" // https://git-scm.com/docs/githooks#_post_merge
+  | "pre-push" // https://git-scm.com/docs/githooks#_pre_push
+  | "pre-receive" // https://git-scm.com/docs/githooks#pre-receive
+  | "update" // https://git-scm.com/docs/githooks#update
+  | "post-receive" // https://git-scm.com/docs/githooks#post-receive
+  | "post-update" // https://git-scm.com/docs/githooks#post-update
+  | "push-to-checkout" // https://git-scm.com/docs/githooks#_push_to_checkout
+  | "pre-auto-gc" // https://git-scm.com/docs/githooks#_pre_auto_gc
+  | "post-rewrite" // https://git-scm.com/docs/githooks#_post_rewrite
+  | "sendemail-validate" // https://git-scm.com/docs/githooks#_sendemail_validate
+  | "fsmonitor-watchman" // https://git-scm.com/docs/githooks#_fsmonitor_watchman
+  | "p4-pre-submit"; // https://git-scm.com/docs/githooks#_p4_pre_submit
 
 export const GIT_HOOKS: Hook[] = [
   "applypatch-msg",
-  "commit-msg",
-  "fsmonitor-watchman",
-  "post-update",
   "pre-applypatch",
+  "post-applypatch",
   "pre-commit",
-  "pre-push",
-  "pre-rebase",
-  "pre-receive",
   "prepare-commit-msg",
+  "commit-msg",
+  "post-commit",
+  "pre-rebase",
+  "post-checkout",
+  "post-merge",
+  "pre-push",
+  "pre-receive",
   "update",
+  "post-receive",
+  "post-update",
+  "push-to-checkout",
+  "pre-auto-gc",
+  "post-rewrite",
+  "sendemail-validate",
+  "fsmonitor-watchman",
+  "p4-pre-submit",
 ];
 
 export function isGitHook(str: string): str is Hook {

--- a/packages/ogh-core/src/gitHooks.ts
+++ b/packages/ogh-core/src/gitHooks.ts
@@ -50,6 +50,8 @@ export const GIT_HOOKS: Hook[] = [
   "p4-pre-submit",
 ];
 
+export const DEFAULT_SCRIPT_PATH = "lib/index.js";
+
 export function isGitHook(str: string): str is Hook {
   return (GIT_HOOKS as string[]).includes(str);
 }
@@ -58,7 +60,12 @@ export function getGitHookFilepath(hookName: Hook): string {
   return resolve(getGitHooksDirectory(), hookName);
 }
 
-function render(packageName: string, hookName: string, scriptPath: string = "lib/index.js", append: boolean = false) {
+function render(
+  packageName: string,
+  hookName: string,
+  scriptPath: string = DEFAULT_SCRIPT_PATH,
+  append: boolean = false
+) {
   return `${append ? "" : "#!/bin/sh\n"}# DO NOT EDIT ${packageName} START
 
 scriptPath="node_modules/${packageName}/${scriptPath}"
@@ -149,8 +156,8 @@ function checkInstalled(packageName: string, hookName: Hook) {
   }
 }
 
-export function installHooks(packageName: string, scriptPath?: string) {
-  GIT_HOOKS.forEach(hookName => {
+export function installHooks(packageName: string, scriptPath: string = DEFAULT_SCRIPT_PATH, hooks: Hook[] = GIT_HOOKS) {
+  hooks.forEach(hookName => {
     if (checkInstalled(packageName, hookName)) {
       return;
     }

--- a/packages/ogh-sample/src/index.ts
+++ b/packages/ogh-sample/src/index.ts
@@ -76,6 +76,6 @@ const oghSampleHook = (args: any, config: any) => {
   }
 };
 
-entrypoint("@yamadayuki/ogh-sample", "lib/index.js")
+entrypoint("@yamadayuki/ogh-sample", { scriptPath: "lib/index.js", hooks: ["pre-commit"] })
   .registerPerformHook(oghSampleHook)
   .parse(process.argv);


### PR DESCRIPTION
## WHY & WHAT

Git has some hooks indicated in https://git-scm.com/docs/githooks .
So I have to support these hooks. And we can choose the hook names to install.

```ts
entrypoint('foo', { hooks: ['pre-commit'] })
  .parse(process.argv)
```
